### PR TITLE
Fix LoadingPlugin + small Fixes

### DIFF
--- a/src/main/java/DummyCore/ASM/DCLoadingPlugin.java
+++ b/src/main/java/DummyCore/ASM/DCLoadingPlugin.java
@@ -1,20 +1,16 @@
 package DummyCore.ASM;
 
-import static DummyCore.Core.CoreInitialiser.mcVersion;
-
-import DummyCore.Core.Core;
-import cpw.mods.fml.relauncher.FMLInjectionData;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin.MCVersion;
+import cpw.mods.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
 import java.io.File;
 import java.util.Map;
 
-@MCVersion(value = mcVersion)
+@MCVersion(value = "1.7.10")
+@TransformerExclusions("DummyCore.ASM.*")
 public class DCLoadingPlugin implements IFMLLoadingPlugin {
 
-    public DCLoadingPlugin() {
-        Core.mcDir = (File) FMLInjectionData.data()[6];
-    }
+    public static File mcDir;
 
     @Override
     public String[] getASMTransformerClass() {
@@ -32,7 +28,9 @@ public class DCLoadingPlugin implements IFMLLoadingPlugin {
     }
 
     @Override
-    public void injectData(Map<String, Object> data) {}
+    public void injectData(Map<String, Object> data) {
+        mcDir = (File) data.get("mcLocation");
+    }
 
     @Override
     public String getAccessTransformerClass() {

--- a/src/main/java/DummyCore/Client/GuiButton_ChangeGUI.java
+++ b/src/main/java/DummyCore/Client/GuiButton_ChangeGUI.java
@@ -9,13 +9,13 @@ import net.minecraft.util.ResourceLocation;
 public class GuiButton_ChangeGUI extends GuiButton {
 
     public GuiButton_ChangeGUI(
-            int p_i1021_1_, int p_i1021_2_, int p_i1021_3_, int p_i1021_4_, int p_i1021_5_, String p_i1021_6_) {
-        super(p_i1021_1_, p_i1021_2_, p_i1021_3_, p_i1021_4_, p_i1021_5_, p_i1021_6_);
+            int stateName, int id, int p_i1021_3_, int p_i1021_4_, int p_i1021_5_, String p_i1021_6_) {
+        super(stateName, id, p_i1021_3_, p_i1021_4_, p_i1021_5_, p_i1021_6_);
     }
 
     @Override
-    public void func_146113_a(SoundHandler p_146113_1_) {
-        p_146113_1_.playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation("gui.button.press"), 1.0F));
+    public void func_146113_a(SoundHandler soundHandlerIn) {
+        soundHandlerIn.playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation("gui.button.press"), 1.0F));
         Minecraft.getMinecraft().displayGuiScreen(new GuiMenuList(Minecraft.getMinecraft().currentScreen));
     }
 }

--- a/src/main/java/DummyCore/Client/GuiElement.java
+++ b/src/main/java/DummyCore/Client/GuiElement.java
@@ -15,137 +15,96 @@ public abstract class GuiElement {
 
     public abstract int getY();
 
-    public void drawTexturedModalRect(
-            int p_73729_1_, int p_73729_2_, int p_73729_3_, int p_73729_4_, int p_73729_5_, int p_73729_6_) {
+    public void drawTexturedModalRect(int x, int y, int textureX, int textureY, int width, int height) {
         float f = 0.00390625F;
         float f1 = 0.00390625F;
         Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
         tessellator.addVertexWithUV(
-                (double) (p_73729_1_ + 0),
-                (double) (p_73729_2_ + p_73729_6_),
+                (double) (x + 0),
+                (double) (y + height),
                 (double) this.zLevel,
-                (double) ((float) (p_73729_3_ + 0) * f),
-                (double) ((float) (p_73729_4_ + p_73729_6_) * f1));
+                (double) ((float) (textureX + 0) * f),
+                (double) ((float) (textureY + height) * f1));
         tessellator.addVertexWithUV(
-                (double) (p_73729_1_ + p_73729_5_),
-                (double) (p_73729_2_ + p_73729_6_),
+                (double) (x + width),
+                (double) (y + height),
                 (double) this.zLevel,
-                (double) ((float) (p_73729_3_ + p_73729_5_) * f),
-                (double) ((float) (p_73729_4_ + p_73729_6_) * f1));
+                (double) ((float) (textureX + width) * f),
+                (double) ((float) (textureY + height) * f1));
         tessellator.addVertexWithUV(
-                (double) (p_73729_1_ + p_73729_5_),
-                (double) (p_73729_2_ + 0),
+                (double) (x + width),
+                (double) (y + 0),
                 (double) this.zLevel,
-                (double) ((float) (p_73729_3_ + p_73729_5_) * f),
-                (double) ((float) (p_73729_4_ + 0) * f1));
+                (double) ((float) (textureX + width) * f),
+                (double) ((float) (textureY + 0) * f1));
         tessellator.addVertexWithUV(
-                (double) (p_73729_1_ + 0),
-                (double) (p_73729_2_ + 0),
+                (double) (x + 0),
+                (double) (y + 0),
                 (double) this.zLevel,
-                (double) ((float) (p_73729_3_ + 0) * f),
-                (double) ((float) (p_73729_4_ + 0) * f1));
+                (double) ((float) (textureX + 0) * f),
+                (double) ((float) (textureY + 0) * f1));
         tessellator.draw();
     }
 
-    public void drawTexturedModelRectFromIcon(
-            int p_94065_1_, int p_94065_2_, IIcon p_94065_3_, int p_94065_4_, int p_94065_5_) {
+    public void drawTexturedModelRectFromIcon(int x, int y, IIcon icon, int width, int height) {
         Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
         tessellator.addVertexWithUV(
-                (double) (p_94065_1_ + 0),
-                (double) (p_94065_2_ + p_94065_5_),
-                (double) this.zLevel,
-                (double) p_94065_3_.getMinU(),
-                (double) p_94065_3_.getMaxV());
+                (double) (x + 0), (double) (y + height), (double) this.zLevel, (double) icon.getMinU(), (double)
+                        icon.getMaxV());
         tessellator.addVertexWithUV(
-                (double) (p_94065_1_ + p_94065_4_),
-                (double) (p_94065_2_ + p_94065_5_),
-                (double) this.zLevel,
-                (double) p_94065_3_.getMaxU(),
-                (double) p_94065_3_.getMaxV());
+                (double) (x + width), (double) (y + height), (double) this.zLevel, (double) icon.getMaxU(), (double)
+                        icon.getMaxV());
         tessellator.addVertexWithUV(
-                (double) (p_94065_1_ + p_94065_4_),
-                (double) (p_94065_2_ + 0),
-                (double) this.zLevel,
-                (double) p_94065_3_.getMaxU(),
-                (double) p_94065_3_.getMinV());
+                (double) (x + width), (double) (y + 0), (double) this.zLevel, (double) icon.getMaxU(), (double)
+                        icon.getMinV());
         tessellator.addVertexWithUV(
-                (double) (p_94065_1_ + 0),
-                (double) (p_94065_2_ + 0),
-                (double) this.zLevel,
-                (double) p_94065_3_.getMinU(),
-                (double) p_94065_3_.getMinV());
+                (double) (x + 0), (double) (y + 0), (double) this.zLevel, (double) icon.getMinU(), (double)
+                        icon.getMinV());
         tessellator.draw();
     }
 
     public static void func_146110_a(
-            int p_146110_0_,
-            int p_146110_1_,
-            float p_146110_2_,
-            float p_146110_3_,
-            int p_146110_4_,
-            int p_146110_5_,
-            float p_146110_6_,
-            float p_146110_7_) {
-        float f4 = 1.0F / p_146110_6_;
-        float f5 = 1.0F / p_146110_7_;
+            int x, int y, float u, float v, int width, int height, float textureWidth, float textureHeight) {
+        float f4 = 1.0F / textureWidth;
+        float f5 = 1.0F / textureHeight;
         Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
         tessellator.addVertexWithUV(
-                (double) p_146110_0_, (double) (p_146110_1_ + p_146110_5_), 0.0D, (double) (p_146110_2_ * f4), (double)
-                        ((p_146110_3_ + (float) p_146110_5_) * f5));
+                (double) x, (double) (y + height), 0.0D, (double) (u * f4), (double) ((v + (float) height) * f5));
         tessellator.addVertexWithUV(
-                (double) (p_146110_0_ + p_146110_4_),
-                (double) (p_146110_1_ + p_146110_5_),
-                0.0D,
-                (double) ((p_146110_2_ + (float) p_146110_4_) * f4),
-                (double) ((p_146110_3_ + (float) p_146110_5_) * f5));
+                (double) (x + width), (double) (y + height), 0.0D, (double) ((u + (float) width) * f4), (double)
+                        ((v + (float) height) * f5));
         tessellator.addVertexWithUV(
-                (double) (p_146110_0_ + p_146110_4_),
-                (double) p_146110_1_,
-                0.0D,
-                (double) ((p_146110_2_ + (float) p_146110_4_) * f4),
-                (double) (p_146110_3_ * f5));
-        tessellator.addVertexWithUV(
-                (double) p_146110_0_, (double) p_146110_1_, 0.0D, (double) (p_146110_2_ * f4), (double)
-                        (p_146110_3_ * f5));
+                (double) (x + width), (double) y, 0.0D, (double) ((u + (float) width) * f4), (double) (v * f5));
+        tessellator.addVertexWithUV((double) x, (double) y, 0.0D, (double) (u * f4), (double) (v * f5));
         tessellator.draw();
     }
 
     public static void func_152125_a(
-            int p_152125_0_,
-            int p_152125_1_,
-            float p_152125_2_,
-            float p_152125_3_,
-            int p_152125_4_,
-            int p_152125_5_,
-            int p_152125_6_,
-            int p_152125_7_,
-            float p_152125_8_,
-            float p_152125_9_) {
-        float f4 = 1.0F / p_152125_8_;
-        float f5 = 1.0F / p_152125_9_;
+            int x,
+            int y,
+            float u,
+            float v,
+            int uWidth,
+            int vHeight,
+            int width,
+            int height,
+            float tileWidth,
+            float tileHeight) {
+        float f4 = 1.0F / tileWidth;
+        float f5 = 1.0F / tileHeight;
         Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
         tessellator.addVertexWithUV(
-                (double) p_152125_0_, (double) (p_152125_1_ + p_152125_7_), 0.0D, (double) (p_152125_2_ * f4), (double)
-                        ((p_152125_3_ + (float) p_152125_5_) * f5));
+                (double) x, (double) (y + height), 0.0D, (double) (u * f4), (double) ((v + (float) vHeight) * f5));
         tessellator.addVertexWithUV(
-                (double) (p_152125_0_ + p_152125_6_),
-                (double) (p_152125_1_ + p_152125_7_),
-                0.0D,
-                (double) ((p_152125_2_ + (float) p_152125_4_) * f4),
-                (double) ((p_152125_3_ + (float) p_152125_5_) * f5));
+                (double) (x + width), (double) (y + height), 0.0D, (double) ((u + (float) uWidth) * f4), (double)
+                        ((v + (float) vHeight) * f5));
         tessellator.addVertexWithUV(
-                (double) (p_152125_0_ + p_152125_6_),
-                (double) p_152125_1_,
-                0.0D,
-                (double) ((p_152125_2_ + (float) p_152125_4_) * f4),
-                (double) (p_152125_3_ * f5));
-        tessellator.addVertexWithUV(
-                (double) p_152125_0_, (double) p_152125_1_, 0.0D, (double) (p_152125_2_ * f4), (double)
-                        (p_152125_3_ * f5));
+                (double) (x + width), (double) y, 0.0D, (double) ((u + (float) uWidth) * f4), (double) (v * f5));
+        tessellator.addVertexWithUV((double) x, (double) y, 0.0D, (double) (u * f4), (double) (v * f5));
         tessellator.draw();
     }
 }

--- a/src/main/java/DummyCore/Client/GuiMainMenuOld.java
+++ b/src/main/java/DummyCore/Client/GuiMainMenuOld.java
@@ -73,7 +73,7 @@ public class GuiMainMenuOld extends GuiMainMenu implements IMainMenu {
     }
 
     @Override
-    public void drawScreen(int p_73863_1_, int p_73863_2_, float p_73863_3_) {
+    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         Tessellator tessellator = Tessellator.instance;
         short short1 = 274;
         int k = this.width / 2 - short1 / 2;
@@ -130,23 +130,23 @@ public class GuiMainMenuOld extends GuiMainMenu implements IMainMenu {
         int k1;
 
         for (k1 = 0; k1 < this.buttonList.size(); ++k1) {
-            drawButton(((GuiButton) this.buttonList.get(k1)), this.mc, p_73863_1_, p_73863_2_);
+            drawButton(((GuiButton) this.buttonList.get(k1)), this.mc, mouseX, mouseY);
         }
 
         for (k1 = 0; k1 < this.labelList.size(); ++k1) {
-            ((GuiLabel) this.labelList.get(k1)).func_146159_a(this.mc, p_73863_1_, p_73863_2_);
+            ((GuiLabel) this.labelList.get(k1)).func_146159_a(this.mc, mouseX, mouseY);
         }
     }
 
-    public void drawButton(GuiButton button, Minecraft p_146112_1_, int p_146112_2_, int p_146112_3_) {
+    public void drawButton(GuiButton button, Minecraft mc, int mouseX, int mouseY) {
         if (button.enabled) {
-            FontRenderer fontrenderer = p_146112_1_.fontRenderer;
-            p_146112_1_.getTextureManager().bindTexture(buttonTextures);
+            FontRenderer fontrenderer = mc.fontRenderer;
+            mc.getTextureManager().bindTexture(buttonTextures);
             GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-            boolean field_146123_n = p_146112_2_ >= button.xPosition
-                    && p_146112_3_ >= button.yPosition
-                    && p_146112_2_ < button.xPosition + button.width
-                    && p_146112_3_ < button.yPosition + button.height;
+            boolean field_146123_n = mouseX >= button.xPosition
+                    && mouseY >= button.yPosition
+                    && mouseX < button.xPosition + button.width
+                    && mouseY < button.yPosition + button.height;
             int k = button.getHoverState(field_146123_n);
             GL11.glEnable(GL11.GL_BLEND);
             OpenGlHelper.glBlendFunc(770, 771, 1, 0);

--- a/src/main/java/DummyCore/Client/MainMenuRegistry.java
+++ b/src/main/java/DummyCore/Client/MainMenuRegistry.java
@@ -1,6 +1,6 @@
 package DummyCore.Client;
 
-import DummyCore.Core.Core;
+import DummyCore.ASM.DCLoadingPlugin;
 import DummyCore.Utils.DummyConfig;
 import DummyCore.Utils.DummyData;
 import DummyCore.Utils.IMainMenu;
@@ -491,7 +491,7 @@ public class MainMenuRegistry {
 
     public static void initMenuConfigs() {
         try {
-            File dir = new File(Core.mcDir, "config");
+            File dir = new File(DCLoadingPlugin.mcDir, "config");
             dir.mkdirs();
             dir = new File(dir, "dcMainMenu");
             if (!dir.exists()) createHelpFile(dir);

--- a/src/main/java/DummyCore/Core/Core.java
+++ b/src/main/java/DummyCore/Core/Core.java
@@ -14,7 +14,6 @@ import net.minecraftforge.common.config.Configuration;
 public class Core {
 
     public static final ArrayList<DCMod> registeredMods = new ArrayList<DCMod>();
-    public static File mcDir;
 
     public static boolean isModRegistered(Class<?> mod) {
         for (DCMod dcm : registeredMods) if (dcm.modClass.equals(mod)) return true;

--- a/src/main/java/DummyCore/Core/CoreInitialiser.java
+++ b/src/main/java/DummyCore/Core/CoreInitialiser.java
@@ -1,10 +1,5 @@
 package DummyCore.Core;
 
-import static DummyCore.Core.CoreInitialiser.mcVersion;
-import static DummyCore.Core.CoreInitialiser.modid;
-import static DummyCore.Core.CoreInitialiser.modname;
-import static DummyCore.Core.CoreInitialiser.version;
-
 import DummyCore.Utils.CommandTransfer;
 import DummyCore.Utils.DummyConfig;
 import DummyCore.Utils.DummyDataUtils;
@@ -15,7 +10,6 @@ import DummyCore.Utils.DummyPacketIMSG_Tile;
 import DummyCore.Utils.DummyTilePacketHandler;
 import DummyCore.Utils.LoadingUtils;
 import DummyCore.Utils.MiscUtils;
-import DummyCore.Utils.ModVersionChecker;
 import DummyCore.Utils.NetProxy_Server;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
@@ -39,12 +33,16 @@ import net.minecraftforge.common.MinecraftForge;
  * @author Modbder
  * @version From DummyCore 1.0
  */
-@Mod(modid = modid, name = modname, version = version, useMetadata = false, acceptedMinecraftVersions = mcVersion)
+@Mod(
+        modid = CoreInitialiser.modid,
+        name = CoreInitialiser.modname,
+        version = CoreInitialiser.version,
+        useMetadata = false,
+        acceptedMinecraftVersions = "[1.7.10]")
 public class CoreInitialiser {
 
     public static final String modid = "DummyCore";
     public static final String modname = "DummyCore";
-    public static final String mcVersion = "1.7.10";
     public static final String version = "GRADLETOKEN_VERSION";
 
     public static CoreInitialiser instance;

--- a/src/main/java/DummyCore/Core/CoreInitialiser.java
+++ b/src/main/java/DummyCore/Core/CoreInitialiser.java
@@ -103,7 +103,6 @@ public class CoreInitialiser {
             LoadingUtils.knownBigASMModifiers.add("CodeChickenCore");
 
         FMLCommonHandler.instance().registerCrashCallable(new DCCrashCallable());
-        ModVersionChecker.addRequest(getClass(), "https://www.dropbox.com/s/iwdfv0mc4qns00f/DummyCoreVersion.txt?dl=1");
     }
 
     @EventHandler

--- a/src/main/java/DummyCore/Utils/CommandTransfer.java
+++ b/src/main/java/DummyCore/Utils/CommandTransfer.java
@@ -12,15 +12,14 @@ public class CommandTransfer extends CommandBase {
     }
 
     @Override
-    public String getCommandUsage(ICommandSender p_71518_1_) {
+    public String getCommandUsage(ICommandSender sender) {
         return "/DummyCore.Transfer <player> <dimensionID>";
     }
 
     @Override
-    public void processCommand(ICommandSender p_71515_1_, String[] p_71515_2_) {
-        int var3 = parseIntWithMin(p_71515_1_, p_71515_2_[1], Integer.MIN_VALUE);
-        EntityPlayerMP player =
-                p_71515_2_.length == 0 ? getCommandSenderAsPlayer(p_71515_1_) : getPlayer(p_71515_1_, p_71515_2_[0]);
+    public void processCommand(ICommandSender sender, String[] args) {
+        int var3 = parseIntWithMin(sender, args[1], Integer.MIN_VALUE);
+        EntityPlayerMP player = args.length == 0 ? getCommandSenderAsPlayer(sender) : getPlayer(sender, args[0]);
         player.travelToDimension(var3);
     }
 }

--- a/src/main/java/DummyCore/Utils/CustomTXTConfig.java
+++ b/src/main/java/DummyCore/Utils/CustomTXTConfig.java
@@ -1,7 +1,6 @@
 package DummyCore.Utils;
 
-import DummyCore.Core.Core;
-import cpw.mods.fml.common.FMLCommonHandler;
+import DummyCore.ASM.DCLoadingPlugin;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -15,7 +14,7 @@ public class CustomTXTConfig {
 
     public static void createCFG() {
         try {
-            File cfgDir = new File(Core.mcDir, "config");
+            File cfgDir = new File(DCLoadingPlugin.mcDir, "config");
             if (!cfgDir.exists()) cfgDir.mkdirs();
 
             File actualCfg = new File(cfgDir, "DummyCoreASMSettings.cfg");
@@ -24,9 +23,7 @@ public class CustomTXTConfig {
             readCfg(actualCfg);
             init = true;
         } catch (Exception e) {
-            FMLCommonHandler.instance()
-                    .raiseException(
-                            e, "[DummyCore]Something went wrong while trying to create ASM configuration!", true);
+            throw new RuntimeException("[DummyCore] Something went wrong while trying to create ASM configuration!", e);
         }
     }
 
@@ -45,9 +42,7 @@ public class CustomTXTConfig {
             pw.flush();
             pw.close();
         } catch (Exception e) {
-            FMLCommonHandler.instance()
-                    .raiseException(
-                            e, "[DummyCore]Something went wrong while trying to create ASM configuration!", true);
+            throw new RuntimeException("[DummyCore] Something went wrong while trying to create ASM configuration!", e);
         }
     }
 
@@ -65,7 +60,7 @@ public class CustomTXTConfig {
             br.close();
             fr.close();
         } catch (Exception e) {
-            LoadingUtils.makeACrash("[DummyCore]Failed to read ASM settings!", CustomTXTConfig.class, e, false);
+            LoadingUtils.makeACrash("[DummyCore] Failed to read ASM settings!", CustomTXTConfig.class, e, false);
         }
     }
 }

--- a/src/main/java/DummyCore/Utils/MiscUtils.java
+++ b/src/main/java/DummyCore/Utils/MiscUtils.java
@@ -642,14 +642,8 @@ public class MiscUtils {
      */
     @Deprecated
     public static void drawTexturedModalRect(
-            int p_73729_1_,
-            int p_73729_2_,
-            int p_73729_3_,
-            int p_73729_4_,
-            int p_73729_5_,
-            int p_73729_6_,
-            int zLevel) {
-        DrawUtils.drawTexturedModalRect(p_73729_1_, p_73729_2_, p_73729_3_, p_73729_4_, p_73729_5_, p_73729_6_, zLevel);
+            int x, int y, int textureX, int textureY, int width, int height, int zLevel) {
+        DrawUtils.drawTexturedModalRect(x, y, textureX, textureY, width, height, zLevel);
     }
 
     /**


### PR DESCRIPTION
Fixes this crash:
```log
[09:16:03] [main/ERROR] [FML]: An error occurred trying to configure the minecraft home at C:\Users\<REDACTED>\Downloads\MultiMC\instances\GT New Horizons\.minecraft for Forge Mod Loader
java.lang.NoClassDefFoundError: net/minecraft/creativetab/CreativeTabs
	at DummyCore.ASM.DCLoadingPlugin.<init>(DCLoadingPlugin.java:16) ~[DummyCore-1.7.10-2.0.2.jar:?]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:1.8.0_311]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(Unknown Source) ~[?:1.8.0_311]
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(Unknown Source) ~[?:1.8.0_311]
	at java.lang.reflect.Constructor.newInstance(Unknown Source) ~[?:1.8.0_311]
	at java.lang.Class.newInstance(Unknown Source) ~[?:1.8.0_311]
	at cpw.mods.fml.relauncher.CoreModManager.loadCoreMod(CoreModManager.java:501) ~[forge-1.7.10-10.13.4.1614-1.7.10-universal.jar:?]
	at cpw.mods.fml.relauncher.CoreModManager.discoverCoreMods(CoreModManager.java:389) ~[forge-1.7.10-10.13.4.1614-1.7.10-universal.jar:?]
	at cpw.mods.fml.relauncher.CoreModManager.handleLaunch(CoreModManager.java:221) ~[forge-1.7.10-10.13.4.1614-1.7.10-universal.jar:?]
	at cpw.mods.fml.relauncher.FMLLaunchHandler.setupHome(FMLLaunchHandler.java:90) [forge-1.7.10-10.13.4.1614-1.7.10-universal.jar:?]
	at cpw.mods.fml.relauncher.FMLLaunchHandler.setupClient(FMLLaunchHandler.java:67) [forge-1.7.10-10.13.4.1614-1.7.10-universal.jar:?]
	at cpw.mods.fml.relauncher.FMLLaunchHandler.configureForClientLaunch(FMLLaunchHandler.java:34) [forge-1.7.10-10.13.4.1614-1.7.10-universal.jar:?]
	at cpw.mods.fml.common.launcher.FMLTweaker.injectIntoClassLoader(FMLTweaker.java:126) [forge-1.7.10-10.13.4.1614-1.7.10-universal.jar:?]
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:115) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_311]
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_311]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_311]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.8.0_311]
	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:210) [NewLaunch.jar:?]
	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:245) [NewLaunch.jar:?]
	at org.multimc.EntryPoint.listen(EntryPoint.java:143) [NewLaunch.jar:?]
	at org.multimc.EntryPoint.main(EntryPoint.java:34) [NewLaunch.jar:?]
Caused by: java.lang.ClassNotFoundException: net.minecraft.creativetab.CreativeTabs
	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:191) ~[launchwrapper-1.12.jar:?]
	at java.lang.ClassLoader.loadClass(Unknown Source) ~[?:1.8.0_311]
	at java.lang.ClassLoader.loadClass(Unknown Source) ~[?:1.8.0_311]
	... 23 more
Caused by: java.lang.NullPointerException
	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:182) ~[launchwrapper-1.12.jar:?]
	at java.lang.ClassLoader.loadClass(Unknown Source) ~[?:1.8.0_311]
	at java.lang.ClassLoader.loadClass(Unknown Source) ~[?:1.8.0_311]
	... 23 more
```
Also, DummyCore no longer tries to check for updates at a no longer existing URL:
![](https://cdn.discordapp.com/attachments/671308978466324501/1053446512383901776/image.png)